### PR TITLE
Change wording

### DIFF
--- a/Lockdown
+++ b/Lockdown
@@ -623,7 +623,7 @@ function check_if_standard_user {
   local audit_command
   local fix_command
   
-  title="${USER} is not an administrator"
+  title="${USER} should not be an administrator"
 
   audit_command="groups | grep -qv 'admin'"
   fix_command=""


### PR DESCRIPTION
Thanks for this excellent utility, it is a helpful contribution to the macOS community!

When this command is run and the user fails the administrator audit, the output wording confused me:

      [❌] {USER} is not an administrator

It wasn't immediately clear to me if this meant - `Failed because the user is not an administrator`, or `Failed because the user is an administrator and should not be`. I realize now it's the latter but I think it would help others to make the wording clearer.

Proposed change:

      [❌] {USER} should not be an administrator

It might be worthwhile to change the wording of all of the step titles to be "should" statements - for example, 'Enable Automatic Updates' -> 'Automatic Updates should be enabled'. This way the writing makes sense in both the context of ❌ and ✅.