### PR TITLE
Catalina Support

### DIFF
--- a/Lockdown
+++ b/Lockdown
@@ -187,7 +187,7 @@ function follow_symlink {
   done
   parent=$(dirname "${source}")
   # get directory of $source
-  path="$(cd -P "${parent}" && pwd)/${base}"
+  lockdown_path="$(cd -P "${parent}" && pwd)/${base}"
   # Build path to Lockdown
 }
 
@@ -203,11 +203,11 @@ function verify_signature {
 
   if [ -x "$(command -v minisign)" ]; then
 
-    if [[ "${path}" =~ "Cellar/mosl" ]]; then
+    if [[ "${lockdown_path}" =~ "Cellar/mosl" ]]; then
       # If installed by Brew 
 
       if ! minisign -x "/usr/local/Cellar/mosl/${lockdown_version_path}/Lockdown.minisig"\
-           -Vm "${path}" -P "RWTiYbJbLl7q6uQ70l1XCvGExizUgEBNDPH0m/1yMimcsfgh542+RDPU" >/dev/null 2>&1; then 
+           -Vm "${lockdown_path}" -P "RWTiYbJbLl7q6uQ70l1XCvGExizUgEBNDPH0m/1yMimcsfgh542+RDPU" >/dev/null 2>&1; then 
         
         echo "[❌] Failed to validate Lockdown signature with minisign"
         exit 1
@@ -215,7 +215,7 @@ function verify_signature {
     
     else
       
-      if ! minisign -Vm "${path}" -P "RWTiYbJbLl7q6uQ70l1XCvGExizUgEBNDPH0m/1yMimcsfgh542+RDPU" >/dev/null 2>&1; then 
+      if ! minisign -Vm "${lockdown_path}" -P "RWTiYbJbLl7q6uQ70l1XCvGExizUgEBNDPH0m/1yMimcsfgh542+RDPU" >/dev/null 2>&1; then 
         echo "[❌] Failed to validate Lockdown signature with minisign"
         exit 1
       fi

--- a/Lockdown
+++ b/Lockdown
@@ -196,7 +196,6 @@ function verify_signature {
   
   # Verify Lockdown signature with minisign
 
-  local path
   local lockdown_version_path
   lockdown_version_path=$(echo "${LOCKDOWN_VERSION}" | tr -d 'v')
 

--- a/Lockdown
+++ b/Lockdown
@@ -2,8 +2,8 @@
 # mOSL/Lockdown
 
 # Lockdown
-#   Lockdown macOS Mojave security settings
-declare -r LOCKDOWN_VERSION="v2.4.0"
+#   Lockdown macOS Catalina security settings
+declare -r LOCKDOWN_VERSION="v3.0.0"
 
 set -uo pipefail
 # -u prevent using undefined variables

--- a/Lockdown
+++ b/Lockdown
@@ -62,7 +62,7 @@ function macos_compatability_check {
   # Check if running on a Mac
   # Check if the Mac is running the supoorted version of macOS 
 
-  local -r supported_macos_version="10.14"
+  local -r supported_macos_version="10.15"
   local os
   local current_macos_version
 

--- a/Lockdown
+++ b/Lockdown
@@ -704,7 +704,7 @@ function check_efi_integrity {
 
 
   if system_profiler SPiBridgeDataType | grep 'Model Name:' | grep -q 'T2'; then 
-    echo "  [⚠️ ] ${title} (${RED}Not supported by this Mac${RESET})"
+    echo "  [⚠️ ] ${title} (${RED}Not supported on Macs with T2 chips${RESET})"
     t2_mac="True"
     return 1 
   fi

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Finally, mOSL will not protect you from the [FSB](https://en.wikipedia.org/wiki/
 
 ## `Full Disk Access` Permission
 
-In macOS Mojave certain application data is protected by the OS. For example, if `Example.app` wishes to access `Contacts.app` data `Example.app` must be given explicit permission via `System Preferences > Security & Privacy > Privacy`. However some application data cannot be accessed via a specific permission. Access to this data requires the `Full Disk Access` permission. 
+In macOS Mojave and later certain application data is protected by the OS. For example, if `Example.app` wishes to access `Contacts.app` data `Example.app` must be given explicit permission via `System Preferences > Security & Privacy > Privacy`. However some application data cannot be accessed via a specific permission. Access to this data requires the `Full Disk Access` permission. 
 
 mOSL requires that `Terminal.app` be given the `Full Disk Access` permission. It needs this permission to audit/fix the following settings: 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # macOS Lockdown (mOSL)
 [![Build Status](https://travis-ci.org/0xmachos/mOSL.svg?branch=master)](https://travis-ci.org/0xmachos/mOSL) [![GitHub Release](https://github-basic-badges.herokuapp.com/release/0xmachos/mOSL.svg)](https://github.com/0xmachos/mOSL/releases/latest)
 
-Bash script to audit and fix macOS Mojave (`10.14.x`) security settings
+Bash script to audit and fix macOS Catalina (`10.15.x`) security settings
 
 ## Warnings
 - **Always** run the [latest release](https://github.com/0xmachos/mOSL/releases/latest) **not** the code in `master`!


### PR DESCRIPTION
Adds support for macOS Catalina (`10.15`). 

- [Change Mojave to Catalina](https://github.com/0xmachos/mOSL/commit/b69b77aa62635ca4c50ef64f997ef973b8732ac4) 
- [Bump LOCKDOWN_VERSION to v3.0.0](https://github.com/0xmachos/mOSL/commit/f588f55cf42c8112b54605eb34140457d1199adc)
- [macos_compatability_check: Increment minor version](https://github.com/0xmachos/mOSL/commit/45f2ba0a2c2e1c0c24bc92782038e61d7d6a671b)
- [Rename path to lockdown_path](https://github.com/0xmachos/mOSL/commit/2021919185f03a0bdfdfc5ad70bc69f90ae1f813)

Some other minor changes.

No change in functionality.

